### PR TITLE
Fixed a bug affecting persistence of non-proplist sumo_docs.

### DIFF
--- a/src/sumo.erl
+++ b/src/sumo.erl
@@ -130,10 +130,7 @@ persist(DocName, State) ->
     undefined -> created;
     _ -> updated
   end,
-
-  NewDoc = sumo_repo:persist(
-    get_repo(DocName), sumo:new_doc(DocName, PropList)
-  ),
+  NewDoc = sumo_repo:persist(get_repo(DocName), sumo:new_doc(DocName, PropList)),
   Ret = DocName:sumo_wakeup(NewDoc#sumo_doc.fields),
   sumo_event:dispatch(DocName, EventName, [Ret]),
   Ret.
@@ -194,7 +191,7 @@ call(DocName, Function, Args) ->
 docs_wakeup(DocName, Docs) ->
   lists:reverse(lists:map(
     fun(Doc) ->
-      DocName:sumo_wakeup(Doc)
+      DocName:sumo_wakeup(Doc#sumo_doc.fields)
     end,
     Docs
   )).

--- a/src/sumo_repo.erl
+++ b/src/sumo_repo.erl
@@ -131,7 +131,7 @@ handle_call(
   #state{handler=Handler,handler_state=HState}=State
 ) ->
   {ok, DocState, NewState} = Handler:persist(Doc, HState),
-  {reply, DocName:sumo_wakeup(DocState), State#state{handler_state=NewState}};
+  {reply, DocState, State#state{handler_state=NewState}};
 
 handle_call(
   {delete, DocName, Id}, _From,


### PR DESCRIPTION
When a client implements a sumo_doc behaviour, the sumo_sleep and sumo_wakeup functions are meant to translate between sumo_db's proplist representation of a document, and the client's representation. 
This fixes a bug when the client's representation is not a proplist itself.  
