### PR TITLE
[WIP #63] Migrations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,4 @@ examples/blog/log
 *.plt
 .rebar
 *.dump
+log*/

--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,4 @@ examples/blog/log
 *.beam
 *.plt
 .rebar
+*.dump

--- a/Makefile
+++ b/Makefile
@@ -9,6 +9,8 @@ DIALYZER_OUT?=${NAME}.plt
 
 ERL_ARGS?=-pa ebin -pa deps/*/ebin -name ${NODE}
 
+CT_SUITES=migration
+
 all: getdeps compile
 	${REBAR} compile
 
@@ -33,7 +35,8 @@ compile:
 	${REBAR} compile
 
 test: compile
-	ERL_AFLAGS="-config test/test.config" ${REBAR} eunit skip_deps=true
+	 ${REBAR} skip_deps=true ct
+	open log/ct/index.html
 
 clean:
 	${REBAR} clean

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HOST?=$(shell hostname)
 NODE?=${NAME}@${HOST}
 DIALYZER_OUT?=${NAME}.plt
 
-ERL_ARGS?=-pa ebin -pa deps/*/ebin -name ${NODE} -s sync
+ERL_ARGS?=-pa ebin -pa deps/*/ebin -name ${NODE} -s sync -config test/test.config
 
 all: getdeps compile
 	${REBAR} compile
@@ -33,7 +33,7 @@ compile:
 	${REBAR} compile
 
 test: compile
-	${REBAR} eunit skip_deps=true
+	ERL_AFLAGS="-config test/test.config" ${REBAR} eunit skip_deps=true
 
 clean:
 	${REBAR} clean

--- a/Makefile
+++ b/Makefile
@@ -7,9 +7,9 @@ HOST?=$(shell hostname)
 NODE?=${NAME}@${HOST}
 DIALYZER_OUT?=${NAME}.plt
 
-ERL_ARGS?=-pa ebin -pa deps/*/ebin -name ${NODE}
+ERL_ARGS?=-pa ebin -pa deps/*/ebin -name ${NODE} -s sync
 
-all: getdeps compile edoc
+all: getdeps compile
 	${REBAR} compile
 
 blog:

--- a/Makefile
+++ b/Makefile
@@ -34,7 +34,7 @@ compile_no_deps:
 compile:
 	${REBAR} compile
 
-test: compile
+tests: compile
 	 ${REBAR} skip_deps=true ct
 	open log/ct/index.html
 

--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,7 @@ HOST?=$(shell hostname)
 NODE?=${NAME}@${HOST}
 DIALYZER_OUT?=${NAME}.plt
 
-ERL_ARGS?=-pa ebin -pa deps/*/ebin -name ${NODE} -s sync -config test/test.config
+ERL_ARGS?=-pa ebin -pa deps/*/ebin -name ${NODE}
 
 all: getdeps compile
 	${REBAR} compile

--- a/README.md
+++ b/README.md
@@ -44,5 +44,31 @@ for a full example. To run it, while being in the top level directory:
 
     make all blog
 
+# Migrations
+
+There's currently a very basic implementation of DB migrations available. A
+`migrations_dir` configuration parameter was added which indicates where sumo
+should look for migrations `*.erl` files, it's default value is `src/migrations`.
+Migration modules should be named with the following format:
+`yyyymmddhhMMss_description_with_undescores`. The most recent migration will be
+considered the one with the most recent `year-month-day-hour-min-sec` value.
+
+In order for migrations to work in a given project, sumo_migration should be
+added to the docs list in sumo's configuration.
+
+The following targets can be added to the project's Makefile:
+
+```Makefile
+migrate:
+    erl -pa ebin -pa deps/*/ebin -s your_app -s sumo migrate -config path/to/config
+
+rollback:
+    erl -pa ebin -pa deps/*/ebin -s your_app -s sumo rollback -config path/to/config
+```
+
+If your migrations folder is not under `src` the you should make sure to compile
+all migration modules and include the path to the compiled files in the call
+to `erl`.
+
 # TODO
  * Get rid of atoms and use lists.

--- a/rebar.config
+++ b/rebar.config
@@ -23,7 +23,8 @@
   {emysql,      "0.*", {git, "git@github.com:Eonblast/Emysql.git",        "master"}},
   {emongo,      ".*",  {git, "git@github.com:marcelog/emongo.git", "marcelog_login_for_2_2_and_higher"}},
   {'sqlite3',   ".*",  {git, "git@github.com:alexeyr/erlang-sqlite3.git", "HEAD"}},
-  {worker_pool, ".*",  {git, "git@github.com:inaka/worker_pool.git",      "master"}}
+  {worker_pool, ".*",  {git, "git@github.com:inaka/worker_pool.git",      "master"}},
+  {sync,        ".*",  {git, "git@github.com:rustyio/sync.git",           "master"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.

--- a/rebar.config
+++ b/rebar.config
@@ -23,8 +23,7 @@
   {emysql,      "0.*", {git, "git@github.com:Eonblast/Emysql.git",        "master"}},
   {emongo,      ".*",  {git, "git@github.com:marcelog/emongo.git", "marcelog_login_for_2_2_and_higher"}},
   {'sqlite3',   ".*",  {git, "git@github.com:alexeyr/erlang-sqlite3.git", "HEAD"}},
-  {worker_pool, ".*",  {git, "git@github.com:inaka/worker_pool.git",      "master"}},
-  {sync,        ".*",  {git, "git@github.com:rustyio/sync.git",           "master"}}
+  {worker_pool, ".*",  {git, "git@github.com:inaka/worker_pool.git",      "master"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.

--- a/rebar.config
+++ b/rebar.config
@@ -2,7 +2,7 @@
 {lib_dirs,["deps", "examples"]}.
 {erl_opts, [
   {parse_transform, lager_transform},
-  {src_dirs, ["src", "examples/blog/src"]},
+  {src_dirs, ["src", "examples/blog/src", "test"]},
   warn_unused_vars,
   warn_export_all,
   warn_shadow_vars,
@@ -27,3 +27,7 @@
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.
+
+%% Common test
+{ct_log_dir,"log/ct"}.
+{ct_extra_params,"-no_auto_compile -dir ebin -pa deps/*/ebin -smp enable -s emysql -s sumo_db -erl_args -config test/test.config"}.

--- a/src/sumo.erl
+++ b/src/sumo.erl
@@ -36,6 +36,9 @@
 -export([find/2, find_all/1, find_all/4, find_by/2, find_by/4, find_one/2]).
 -export([call/2, call/3]).
 
+%%% API for migrations.
+-export([migrate/0, rollback/0]).
+
 -type schema_name() :: atom().
 
 -type field_attr()  :: id|unique|index|not_null|auto_increment|{length, integer()}.
@@ -243,3 +246,15 @@ new_field(Name, Type, Attributes) ->
 -spec new_field(field_name(), field_type()) -> field().
 new_field(Name, Type) ->
   new_field(Name, Type, []).
+
+%% @doc Runs all migrations to get the DB up to date.
+-spec migrate() -> ok | {error, term()}.
+migrate() ->
+    sumo_migration:migrate(),
+    halt(0).
+
+%% @doc Rolls back the last migration and downgrades the DB version.
+-spec rollback() -> ok | {error, term()}.
+rollback() ->
+    sumo_migration:rollback(),
+    halt(0).

--- a/src/sumo.erl
+++ b/src/sumo.erl
@@ -250,11 +250,9 @@ new_field(Name, Type) ->
 %% @doc Runs all migrations to get the DB up to date.
 -spec migrate() -> ok | {error, term()}.
 migrate() ->
-    sumo_migration:migrate(),
-    halt(0).
+    sumo_migration:migrate().
 
 %% @doc Rolls back the last migration and downgrades the DB version.
 -spec rollback() -> ok | {error, term()}.
 rollback() ->
-    sumo_migration:rollback(),
-    halt(0).
+    sumo_migration:rollback().

--- a/src/sumo_migration.erl
+++ b/src/sumo_migration.erl
@@ -25,7 +25,7 @@ migrate() ->
     ensure_sumo_migration_doc(),
     LastVersion = last_migration_version(),
     Versions = migration_update_list(LastVersion),
-    lists:foreach(fun(M) -> run_migration(M) end, Versions).
+    lists:foreach(fun run_migration/1, Versions).
 
 -spec rollback() -> ok.
 rollback() ->

--- a/src/sumo_migration.erl
+++ b/src/sumo_migration.erl
@@ -1,0 +1,85 @@
+-module(sumo_migration).
+
+-behavior(sumo_doc).
+
+-export([migrate/0, rollback/0]).
+
+-export([migration_update_list/1]).
+
+%%% sumo_db callbacks
+-export([sumo_schema/0, sumo_wakeup/1, sumo_sleep/1]).
+
+-callback up() -> string().
+-callback down() -> string().
+
+-type migration() :: atom().
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Exported
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec migrate() -> ok.
+migrate() ->
+    ensure_sumo_migration_doc(),
+    LastMigration = last_migration_update(),
+    Migrations = migration_update_list(LastMigration),
+    lists:foreach(fun(M) -> M:up() end, Migrations).
+
+-spec rollback() -> ok.
+rollback() ->
+    ensure_sumo_migration_doc(),
+    ok.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% sumo_doc callbacks
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec sumo_schema() -> sumo:schema().
+sumo_schema() ->
+    Fields = [sumo:new_field(version, string)],
+    sumo:new_schema(?MODULE, Fields).
+
+-spec sumo_sleep(migration()) -> sumo:doc().
+sumo_sleep(Migration) ->
+    [{version, Migration}].
+
+-spec sumo_wakeup(sumo:doc()) -> migration().
+sumo_wakeup(Migration) ->
+    VersionBin = proplists:get_value(version, Migration),
+    binary_to_atom(VersionBin, utf8).
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Internal
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+%% @doc Make sure the schema_version table is present in the datastore.
+-spec ensure_sumo_migration_doc() -> ok.
+ensure_sumo_migration_doc() ->
+    sumo:create_schema(?MODULE).
+
+-spec last_migration_update() -> migration().
+last_migration_update() ->
+    Migrations = sumo:find_all(?MODULE),
+    lists:max(Migrations).
+
+-spec migration_update_list(migration()) -> [migration()].
+migration_update_list(LastMigration) ->
+    MigrationsDir = migrations_dir(),
+    Files = filelib:wildcard("*.erl", MigrationsDir),
+    F = compose([fun filename:rootname/1, fun list_to_atom/1]),
+    AvailableMigrations = lists:map(F, Files),
+    lists:filter(fun(X) -> X > LastMigration end, AvailableMigrations).
+
+-spec migrations_dir() -> string().
+migrations_dir() ->
+    case application:get_env(migrations_dir, sumo_db) of
+        undefined -> "src/migrations";
+        Dir -> Dir
+    end.
+
+-spec compose([fun()]) -> fun().
+compose(Funs) ->
+    Compose = fun(F, X) -> F(X) end,
+    fun(X) ->
+            lists:foldl(Compose, X, Funs)
+    end.

--- a/test/migration_SUITE.erl
+++ b/test/migration_SUITE.erl
@@ -1,0 +1,62 @@
+-module(migration_SUITE).
+
+-export([
+         all/0,
+         init_per_suite/1,
+         end_per_suite/1
+        ]).
+
+-export([
+         migrate/1,
+         rollback/1
+        ]).
+
+-define(EXCLUDED_FUNS,
+        [
+         module_info,
+         all,
+         test,
+         init_per_suite,
+         end_per_suite
+        ]).
+
+-type config() :: [{atom(), term()}].
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%% Common test
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+-spec all() -> [atom()].
+all() ->
+    Exports = ?MODULE:module_info(exports),
+    [F || {F, _} <- Exports, not lists:member(F, ?EXCLUDED_FUNS)].
+
+-spec init_per_suite(config()) -> config().
+init_per_suite(Config) ->
+    application:ensure_all_started(emysql),
+    application:ensure_all_started(sumo_db),
+    sumo:delete_all(sumo_migration),
+    Config.
+
+-spec end_per_suite(config()) -> config().
+end_per_suite(Config) ->
+    Config.
+
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+%%% Tests cases
+%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+migrate(_Config) ->
+    sumo:migrate(),
+    [_, _, _] = sumo:find_all(sumo_migration).
+
+rollback(_Config) ->
+    [_, _, _] = sumo:find_all(sumo_migration),
+    sumo:rollback(),
+    [_, _] = sumo:find_all(sumo_migration),
+    sumo:rollback(),
+    [_] = sumo:find_all(sumo_migration),
+    sumo:rollback(),
+    [] = sumo:find_all(sumo_migration),
+    sumo:rollback(),
+    sumo:rollback().

--- a/test/migrations/20140901_mig1.erl
+++ b/test/migrations/20140901_mig1.erl
@@ -1,0 +1,13 @@
+-module('20140901_mig1').
+
+-behavior(sumo_migration).
+
+-export([up/0, down/0]).
+
+up() ->
+    io:format("=== ~p up/0~n", [?MODULE]),
+    ok.
+
+down() ->
+    io:format("=== ~p down/0~n", [?MODULE]),
+    ok.

--- a/test/migrations/20140902_mig.erl
+++ b/test/migrations/20140902_mig.erl
@@ -1,0 +1,13 @@
+-module('20140902_mig').
+
+-behavior(sumo_migration).
+
+-export([up/0, down/0]).
+
+up() ->
+    io:format("=== ~p up/0~n", [?MODULE]),
+    ok.
+
+down() ->
+    io:format("=== ~p down/0~n", [?MODULE]),
+    ok.

--- a/test/migrations/20140903_mig.erl
+++ b/test/migrations/20140903_mig.erl
@@ -1,0 +1,13 @@
+-module('20140903_mig').
+
+-behavior(sumo_migration).
+
+-export([up/0, down/0]).
+
+up() ->
+    io:format("=== ~p up/0~n", [?MODULE]),
+    ok.
+
+down() ->
+    io:format("=== ~p down/0~n", [?MODULE]),
+    ok.

--- a/test/test.config
+++ b/test/test.config
@@ -2,7 +2,7 @@
  {
    sumo_db,
    [
-    {migrations_dir, "../test/migrations"},
+    {migrations_dir, "../../../test/migrations"},
     {log_queries, true},
     {query_timeout, 30000},
     {storage_backends,

--- a/test/test.config
+++ b/test/test.config
@@ -1,0 +1,44 @@
+[
+ {
+   sumo_db,
+   [
+    {migrations_dir, "../test/migrations"},
+    {log_queries, true},
+    {query_timeout, 30000},
+    {storage_backends,
+     [{sumo_test_backend,
+       sumo_backend_mysql,
+       [{username, "root"},
+        {password, ""},
+        {host,     "127.0.0.1"},
+        {port,     3306},
+        {database, "sumo_test"},
+        {poolsize, 10}]
+      }
+     ]
+    },
+    {repositories,
+     [{sumo_test_mysql,
+       sumo_repo_mysql,
+       [{storage_backend, sumo_test_backend},
+        {workers, 10}]
+      }
+     ]
+    },
+    {docs,
+     [
+      {sumo_migration, sumo_test_mysql}
+     ]
+    },
+    {events,
+     []
+    }
+   ]
+ },
+ {
+   sasl,
+   [
+    {sasl_error_logger, false}
+   ]
+ }
+].

--- a/variables-ct@jfacorro
+++ b/variables-ct@jfacorro
@@ -1,0 +1,4 @@
+{config,[]}.
+{event_handler,[]}.
+{ct_hooks,[]}.
+{enable_builtin_hooks,undefined}.


### PR DESCRIPTION
A `migrations_dir` configuration parameter was added which indicates where `sumo` should look for migrations `*.erl` files, it's default value is `src/migrations`. Migration modules should be named with the following format: `yyyymmddhhMMss_description_with_undescores`. The most recent migration will be considered the one with the most recent `year-month-day-hour-min-sec` value.

In order for migrations to work in a given project, `sumo_migration` should be added to the `docs` list in `sumo`'s configuration.

The following targets can be added to the project's `Makefile`:

```Makefile
migrate:
    erl -pa ebin -pa deps/*/ebin -s your_app -s sumo migrate -config path/to/config

rollback:
    erl -pa ebin -pa deps/*/ebin -s your_app -s sumo rollback -config path/to/config
```

 If your `migrations` folder is not under `src` the you should make sure to compile them and include the path to the compiled files in the call to `erl`. 