### PR TITLE
Fixed rebar.config to not use the git account for github.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -20,11 +20,11 @@
 ]}.
 {deps, [
   {'lager',     ".*",  {git, "git://github.com/basho/lager.git",          "2.0.3"}},
-  {emysql,      "0.*", {git, "git@github.com:Eonblast/Emysql.git",        "v0.4.1"}},
-  {emongo,      ".*",  {git, "git@github.com:inaka/emongo.git",           "v0.2.1"}},
-  {'sqlite3',   ".*",  {git, "git@github.com:alexeyr/erlang-sqlite3.git", "v1.0.1"}},
-  {'tirerl',    ".*",  {git, "git@github.com:inaka/tirerl",               "0.1.0"}},
-  {worker_pool, ".*",  {git, "git@github.com:inaka/worker_pool.git",      "1.0"}}
+  {emysql,      "0.*", {git, "git://github.com/Eonblast/Emysql.git",        "v0.4.1"}},
+  {emongo,      ".*",  {git, "git://github.com/inaka/emongo.git",           "v0.2.1"}},
+  {'sqlite3',   ".*",  {git, "git://github.com/alexeyr/erlang-sqlite3.git", "v1.0.1"}},
+  {'tirerl',    ".*",  {git, "git://github.com/inaka/tirerl",               "0.1.0"}},
+  {worker_pool, ".*",  {git, "git://github.com/inaka/worker_pool.git",      "1.0"}}
 ]}.
 {xref_warnings, true}.
 {xref_checks, [undefined_function_calls, undefined_functions, locals_not_used, deprecated_function_calls, deprecated_functions]}.


### PR DESCRIPTION
When github allows public and anonymous access to code, use that
rather than relying on access through the 'git' account. Also,
many systems like the Mac OS X ship with broken or incomplete ssh
implementations; in this case the lack of /usr/libexec/ssh-askpass
which makes fetching dependencies a not so happy experience as
reps simply fail to download.
