### PR TITLE
Misc changes to help build cleanly.

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -19,11 +19,11 @@
   warn_untyped_record, debug_info
 ]}.
 {deps, [
-  {'lager',     ".*",  {git, "git://github.com/basho/lager.git",          "2.0.3"}},
+  {lager,       ".*",  {git, "git://github.com/basho/lager.git",            "2.0.3"}},
   {emysql,      "0.*", {git, "git://github.com/Eonblast/Emysql.git",        "v0.4.1"}},
   {emongo,      ".*",  {git, "git://github.com/inaka/emongo.git",           "v0.2.1"}},
-  {'sqlite3',   ".*",  {git, "git://github.com/alexeyr/erlang-sqlite3.git", "v1.0.1"}},
-  {'tirerl',    ".*",  {git, "git://github.com/inaka/tirerl",               "0.1.0"}},
+  {sqlite3,     ".*",  {git, "git://github.com/alexeyr/erlang-sqlite3.git", "v1.0.1"}},
+  {tirerl,      ".*",  {git, "git://github.com/inaka/tirerl",               "0.1.0"}},
   {worker_pool, ".*",  {git, "git://github.com/inaka/worker_pool.git",      "1.0"}}
 ]}.
 {xref_warnings, true}.

--- a/src/sumo.erl
+++ b/src/sumo.erl
@@ -55,7 +55,7 @@
 
 -export_type([schema/0, field/0]).
 
-%% @doc the user representation of a doc (i.e. not the proplists)
+%% The user representation of a doc (i.e. not the proplists)
 -type user_doc()    :: term().
 
 -export_type([user_doc/0]).

--- a/src/sumo_doc.erl
+++ b/src/sumo_doc.erl
@@ -22,7 +22,7 @@
 -github("https://github.com/inaka").
 -license("Apache License 2.0").
 
-%% @doc Returns all behavior callbacks.
+%% Returns all behavior callbacks.
 -callback sumo_schema() -> sumo:schema().
 -callback sumo_wakeup(sumo:doc()) -> sumo:user_doc().
 -callback sumo_sleep(sumo:user_doc()) -> sumo:doc().


### PR DESCRIPTION
It seems edoc is pretty picky about where one uses doctags. Fixed
it so that master builds without any compile-time warnings or
errors. Also changed rebar.config for better appeaance.
