### PR TITLE
Move epgsql deps dir to match rebar location

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,12 +1,12 @@
 PROJECT = sumo_db
 
-DEPS = lager emysql emongo tirerl pgsql wpool
+DEPS = lager emysql emongo tirerl epgsql wpool
 
 dep_lager = git https://github.com/basho/lager.git 2.1.0
 dep_emysql = git https://github.com/Eonblast/Emysql.git v0.4.1
 dep_emongo = git https://github.com/inaka/emongo.git v0.2.1
 dep_tirerl = git https://github.com/inaka/tirerl 0.1.0
-dep_pgsql = git https://github.com/epgsql/epgsql 2.0.0
+dep_epgsql = git https://github.com/epgsql/epgsql 2.0.0
 dep_wpool = git https://github.com/inaka/worker_pool.git 1.0
 
 TEST_DEPS = mixer

--- a/src/sumo_store_pgsql.erl
+++ b/src/sumo_store_pgsql.erl
@@ -21,7 +21,7 @@
 -author("Juan Facorro <juan@inaka.net>").
 -license("Apache License 2.0").
 
--include_lib("pgsql/include/pgsql.hrl").
+-include_lib("epgsql/include/pgsql.hrl").
 
 -behavior(sumo_store).
 


### PR DESCRIPTION
Related to #112.  Despite the fix that @jfacorro applied, I still am unable to get it to compile with Rebar.

The issue is related to the dependency directory:  Rebar clones the epgsql dependency into `deps/epgsql/...` and sumo expecting it in `deps/pgsql/...`  I haven't found a way to configure this in Rebar, so I've changed the dependency name to `epgsql`,  configured it in the Makefile and updated `sumo_store_pgsql.erl` to match.  I tested with make & Rebar -- both appear to work.