### PR TITLE
Cabol.122.riak backend config enhancement

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,7 @@ First, let's create and activate a bucket type simply called maps that is set up
 to store Riak maps:
 
     $ riak-admin bucket-type create maps '{"props":{"datatype":"map"}}'
-    $ riak-admin bucket-type activate mapsdmin bucket-type activate maps
+    $ riak-admin bucket-type activate maps
 
 Now, let's create a search index called `sumo_test_index` using the default
 schema:

--- a/src/sumo_backend_riak.erl
+++ b/src/sumo_backend_riak.erl
@@ -29,31 +29,25 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%% Public API.
--export(
-  [ get_connection/1,
-    get_state/1
-  ]).
+-export([get_connection/1]).
 
 %%% Exports for sumo_backend
--export(
-  [ start_link/2
-  ]).
+-export([start_link/2]).
 
 %%% Exports for gen_server
--export(
-  [ init/1
-  , handle_call/3
-  , handle_cast/2
-  , handle_info/2
-  , terminate/2
-  , code_change/3
-  ]).
+-export([ init/1
+        , handle_call/3
+        , handle_cast/2
+        , handle_info/2
+        , terminate/2
+        , code_change/3
+        ]).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Types.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--record(state, {conn :: pid(), bucket :: binary(), index :: binary()}).
+-record(state, {conn :: pid()}).
 -type state() :: #state{}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -68,10 +62,6 @@ start_link(Name, Options) ->
 get_connection(Name) ->
   gen_server:call(Name, get_connection).
 
--spec get_state(atom() | pid()) -> state().
-get_state(Name) ->
-  gen_server:call(Name, get_state).
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% gen_server stuff.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -82,23 +72,14 @@ init(Options) ->
   Host = proplists:get_value(host, Options, "127.0.0.1"),
   Port = proplists:get_value(port, Options, 8087),
   Opts = riak_opts(Options),
-  %% Get DB parameters
-  BucketType = iolist_to_binary(
-    proplists:get_value(bucket_type, Options)),
-  Bucket = iolist_to_binary(
-    proplists:get_value(bucket, Options, <<"sumo_test">>)),
-  Index = iolist_to_binary(
-    proplists:get_value(index, Options, <<"sumo_test_index">>)),
   %% Place Riak connection
   {ok, Conn} = riakc_pb_socket:start_link(Host, Port, Opts),
   %% Initial state
-  {ok, #state{conn = Conn, bucket = {BucketType, Bucket}, index = Index}}.
+  {ok, #state{conn = Conn}}.
 
 -spec handle_call(term(), term(), state()) -> {reply, term(), state()}.
 handle_call(get_connection, _From, State = #state{conn = Conn}) ->
-  {reply, Conn, State};
-handle_call(get_state, _From, State) ->
-  {reply, State, State}.
+  {reply, Conn, State}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Unused Callbacks

--- a/src/sumo_backend_riak.erl
+++ b/src/sumo_backend_riak.erl
@@ -29,7 +29,7 @@
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
 %%% Public API.
--export([get_connection/1, checkin_conn/2, checkout_conn/1]).
+-export([get_connection/1]).
 
 %%% Exports for sumo_backend
 -export([start_link/2]).
@@ -47,13 +47,9 @@
 %% Types.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
--type r_host() :: iolist() | string().
--type r_port() :: non_neg_integer().
--type r_opts() :: [term()].
--type r_pool() :: [pid()].
-
--record(state, {conn_args      :: {r_host(), r_port(), r_opts()},
-                conn_pool = [] :: r_pool()}).
+-record(state, {host :: string(),
+                port :: non_neg_integer(),
+                opts :: [term()]}).
 -type state() :: #state{}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -68,14 +64,6 @@ start_link(Name, Options) ->
 get_connection(Name) ->
   gen_server:call(Name, get_connection).
 
--spec checkin_conn(atom() | pid(), pid()) -> atom().
-checkin_conn(Name, Conn) ->
-  gen_server:call(Name, {checkin_conn, Conn}).
-
--spec checkout_conn(atom() | pid()) -> atom().
-checkout_conn(Name) ->
-  gen_server:call(Name, checkout_conn).
-
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% gen_server stuff.
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
@@ -85,63 +73,17 @@ init(Options) ->
   %% Get connection parameters
   Host = proplists:get_value(host, Options, "127.0.0.1"),
   Port = proplists:get_value(port, Options, 8087),
-  PoolSize = proplists:get_value(poolsize, Options, 10),
   Opts = riak_opts(Options),
-  %% Create Riak connection pool
-  F = fun(_E, Acc) ->
-        {ok, Conn} = riakc_pb_socket:start_link(Host, Port, Opts),
-        [Conn | Acc]
-      end,
-  ConnPool = lists:foldl(F, [], lists:seq(1, PoolSize)),
-  %% Initial state
-  {ok, #state{conn_args = {Host, Port, Opts}, conn_pool = ConnPool}}.
+  {ok, #state{host = Host, port = Port, opts = Opts}}.
 
-%% @todo: These are workarounds, a real connection pool needs to be added.
-%% Workaround 1: when the store calls 'get_connection', a new Riak connection
-%% is returned - one to one model (between connection and store).
-%% Workaround 2: a simple list (LIFO) was added to hold a set of connections
-%% that are created in the 'init' function (see code above). When the store
-%% needs a connection, must call 'checkout_conn' to get the Pid, and when
-%% it finish, must call 'checkin_conn'. These operations have some problems,
-%% for instance, the don't consider an overflow, so the amount of new
-%% connection are not watched, so in case of high concurrency, exist the
-%% risk of have so many connection hitting the DB and causing contention.
+%% @todo: implement connection pool.
+%% In other cases is a built-in feature of the client.
 -spec handle_call(term(), term(), state()) -> {reply, term(), state()}.
 handle_call(get_connection,
             _From,
-            State = #state{conn_args = {Host, Port, Opts}}) ->
+            State = #state{host = Host, port = Port, opts = Opts}) ->
   {ok, Conn} = riakc_pb_socket:start_link(Host, Port, Opts),
-  {reply, Conn, State};
-handle_call({checkin_conn, Conn},
-            _From,
-            State = #state{conn_args = {Host, Port, Opts},
-                           conn_pool = ConnPool}) ->
-  NewConn = case is_process_alive(Conn) of
-              true ->
-                Conn;
-              false ->
-                {ok, Conn0} = riakc_pb_socket:start_link(Host, Port, Opts),
-                Conn0
-            end,
-  {reply, ok, State#state{conn_pool = [NewConn | ConnPool]}};
-handle_call(checkout_conn,
-            _From,
-            State = #state{conn_args = {Host, Port, Opts}, conn_pool = []}) ->
-  {ok, Conn} = riakc_pb_socket:start_link(Host, Port, Opts),
-  {reply, Conn, State#state{conn_pool = [Conn]}};
-handle_call(checkout_conn,
-            _From,
-            State = #state{conn_args = {Host, Port, Opts},
-                           conn_pool = ConnPool}) ->
-  [Conn | _T] = ConnPool,
-  NewConn = case is_process_alive(Conn) of
-              true ->
-                Conn;
-              false ->
-                {ok, Conn0} = riakc_pb_socket:start_link(Host, Port, Opts),
-                Conn0
-            end,
-  {reply, NewConn, State#state{conn_pool = (ConnPool -- [Conn])}}.
+  {reply, Conn, State}.
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %% Unused Callbacks

--- a/src/sumo_store_riak.erl
+++ b/src/sumo_store_riak.erl
@@ -237,12 +237,12 @@ doc_id(Doc) ->
   sumo_internal:get_field(IdField, Doc).
 
 %% @private
-new_doc(Doc, #state{conn = Conn, bucket = Bucket, write_quorum = W}) ->
+new_doc(Doc, #state{conn = Conn, bucket = Bucket, write_quorum = Wq}) ->
   DocName = sumo_internal:doc_name(Doc),
   IdField = sumo_internal:id_field_name(DocName),
   Id = case sumo_internal:get_field(IdField, Doc) of
          undefined ->
-           case update_map(Conn, Bucket, undefined, doc_to_rmap(Doc), W) of
+           case update_map(Conn, Bucket, undefined, doc_to_rmap(Doc), Wq) of
              {ok, RiakMapId} -> RiakMapId;
              {error, Error}  -> throw(Error);
              _               -> throw(unexpected)

--- a/test/test.config
+++ b/test/test.config
@@ -42,10 +42,7 @@
       {sumo_test_backend_riak,
        sumo_backend_riak,
        [{host, "127.0.0.1"},
-        {port, 8087},
-        {bucket_type, "maps"},
-        {bucket, "sumo_test"},
-        {index, "sumo_test_index"}]
+        {port, 8087}]
       }
      ]
     },
@@ -73,7 +70,12 @@
       {sumo_test_riak,
        sumo_store_riak,
        [{storage_backend, sumo_test_backend_riak},
-        {workers, 10}]
+        {workers, 10},
+        {bucket_type, "maps"},
+        {bucket, "sumo_test"},
+        {index, "sumo_test_index"},
+        {w_args, [{w, 2}, {pw, 0}, {dw, 0}, {returnbody, false}]},
+        {r_args, [{r, 2}, {pr, 0}]}]
       }
      ]
     },

--- a/test/test.config
+++ b/test/test.config
@@ -42,7 +42,8 @@
       {sumo_test_backend_riak,
        sumo_backend_riak,
        [{host, "127.0.0.1"},
-        {port, 8087}]
+        {port, 8087},
+        {poolsize, 10}]
       }
      ]
     },


### PR DESCRIPTION
1. Configuration of Riak backend was modified to support bucket per store, and stores can share one backend.
2. Some workarounds were added to mitigate the problem with connection pool, which in case of Riak (and is the same with PostgreSQL) is not handled by native Erlang client. Even though, it needs to be modified, providing a real connection pool solution.
### Workaround 1:
when the store calls `get_connection`, a new Riak connection is returned - one to one model (between connection and store).
### Workaround 2:
A simple list (LIFO) was added to hold a set of connections that are created in the `sumo_backend_riak:init` function. When the store needs a connection, must call `sumo_backend_riak:checkout_conn` to get the Pid, and when it finish, must call `sumo_backend_riakcheckin_conn`. These operations have some problems, for instance, the don't consider an overflow, so the amount of new connection are not watched, so in case of high concurrency, exist the risk of have so many connection hitting the DB and causing contention.

> **Note:** This is a temporary solution, a real good solution is still needed. Please check workaround 2 and see if is good for now or not.
