### PR TITLE
#130 Fix find_by ID function in sumo_store_riak to return empty list whe...

### DIFF
--- a/src/sumo_store_riak.erl
+++ b/src/sumo_store_riak.erl
@@ -198,6 +198,8 @@ find_by(DocName,
         {ok, RMap} ->
           Val = rmap_to_doc(DocName, RMap),
           {ok, [Val], State};
+        {error, {notfound, _}} ->
+          {ok, [], State};
         {error, Error} ->
           {error, Error, State}
       end;


### PR DESCRIPTION
Module `sumo_store_riak` was modified to return an empty list when `find_by` ID function is invoked and data is not found.