### PR TITLE
Calling sumo:persist with a doc with no id field fails

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,5 +1,7 @@
 PROJECT = sumo_db
 
+CONFIG ?= test/test.config
+
 DEPS = lager emysql emongo tirerl epgsql wpool riakc uuid
 
 dep_lager = git https://github.com/basho/lager.git 2.1.1
@@ -30,13 +32,12 @@ COMPILE_FIRST += sumo_backend sumo_doc sumo_store
 # Commont Test Config
 
 TEST_ERLC_OPTS += +'{parse_transform, lager_transform}'
-CT_OPTS = -cover test/sumo.coverspec -vvv -erl_args -config test/test.config
+CT_OPTS = -cover test/sumo.coverspec -vvv -erl_args -config ${CONFIG}
 
-CONFIG ?= test/test.config
 SHELL_OPTS = -name ${PROJECT}@`hostname` -config ${CONFIG} -s sync
 
 test-shell: build-ct-suites app
-	erl -pa ebin -pa deps/*/ebin -pa test -s lager -s sync -config test/test.config
+	erl -pa ebin -pa deps/*/ebin -pa test -s lager -s sync -config ${CONFIG}
 
 erldocs:
 	erldocs . -o docs

--- a/src/sumo.erl
+++ b/src/sumo.erl
@@ -172,7 +172,7 @@ find_by(DocName, Conditions, SortFields0, Limit, Offset) ->
 persist(DocName, State) ->
   IdField = sumo_internal:id_field_name(DocName),
   DocMap = DocName:sumo_sleep(State),
-  EventName = case maps:get(IdField, DocMap) of
+  EventName = case maps:get(IdField, DocMap, undefined) of
                 undefined -> created;
                 _ -> updated
               end,

--- a/test/sumo_test_utils.erl
+++ b/test/sumo_test_utils.erl
@@ -15,6 +15,7 @@ start_apps() ->
   application:ensure_all_started(epgsql),
   application:ensure_all_started(emongo),
   application:ensure_all_started(tirerl),
+  mnesia:create_schema([node()]),
   application:ensure_all_started(mnesia),
   application:ensure_all_started(sumo_db).
 


### PR DESCRIPTION
…with this error:
```erlang
** exception error: bad_key
     in function  maps:get/2
        called as maps:get(id,
```
It should work as if the value was `undefined`