### PR TITLE
Error using sumo:find to retrieve an inexistent element

### DIFF
--- a/src/sumo_store_mnesia.erl
+++ b/src/sumo_store_mnesia.erl
@@ -149,9 +149,12 @@ find_by(DocName, Conditions, [], Limit, Offset, State) ->
         fun() -> mnesia:select(DocName, MatchSpec) end;
       Limit ->
         fun() ->
-          {ManyItems, _Cont} =
-            mnesia:select(DocName, MatchSpec, Offset + Limit, read),
-          lists:sublist(ManyItems, Offset + 1, Limit)
+          case mnesia:select(DocName, MatchSpec, Offset + Limit, read) of
+            {ManyItems, _Cont} ->
+              lists:sublist(ManyItems, Offset + 1, Limit);
+            '$end_of_table' ->
+              []
+          end
         end
     end,
   case mnesia:transaction(Transaction) of

--- a/test/sumo_basic_SUITE.erl
+++ b/test/sumo_basic_SUITE.erl
@@ -8,6 +8,7 @@
         ]).
 
 -export([
+         find/1,
          find_all/1,
          find_by/1,
          delete_all/1,
@@ -54,6 +55,9 @@ end_per_suite(Config) ->
 %%% Exported Tests Functions
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
+find(_Config) ->
+  run_all_stores(fun find_module/1).
+
 find_all(_Config) ->
   run_all_stores(fun find_all_module/1).
 
@@ -83,6 +87,12 @@ init_store(Module) ->
 
   %% Sync Timeout.
   sync_timeout(Module).
+
+find_module(Module) ->
+  [First, Second | _] = sumo:find_all(Module),
+  First = sumo:find(Module, Module:id(First)),
+  Second = sumo:find(Module, Module:id(Second)),
+  notfound = sumo:find(Module, 0).
 
 find_all_module(Module) ->
   6 = length(sumo:find_all(Module)).


### PR DESCRIPTION
```erlang
{nocatch,[{reason,{error,{{badmatch,'$end_of_table'},[{sumo_store_mnesia,'-find_by/6-fun-1-',4,[{file,"src/sumo_store_mnesia.erl"},{line,152}]},{mnesia_tm,apply_fun,3,[{file,"mnesia_tm.erl"},{line,833}]},{mnesia_tm,execute_transaction...
```