### PR TITLE
Make elasticsearch backend compatible with the others

### DIFF
--- a/src/sumo_store_elasticsearch.erl
+++ b/src/sumo_store_elasticsearch.erl
@@ -250,29 +250,29 @@ normalize_type(datetime) -> binary;
 normalize_type(Type) -> Type.
 
 normalize_fields(Doc) ->
-  FieldList = maps:to_list(Doc),
-  lists:foldl(
-    fun ({K, {_, _, _} = FieldValue}, AccDoc) ->
-          maps:put(K, iso8601:format({FieldValue, {0, 0, 0}}), AccDoc);
-        ({K, {{_, _, _}, {_, _, _}} = FieldValue}, AccDoc) ->
-          maps:put(K, iso8601:format(FieldValue), AccDoc);
-        ({_K, _FieldValue}, AccDoc) ->
-          AccDoc
-    end, Doc, FieldList).
+    FieldList = maps:to_list(Doc),
+    lists:foldl(
+        fun ({K, {_, _, _} = FieldValue}, AccDoc) ->
+                maps:put(K, iso8601:format({FieldValue, {0, 0, 0}}), AccDoc);
+            ({K, {{_, _, _}, {_, _, _}} = FieldValue}, AccDoc) ->
+                maps:put(K, iso8601:format(FieldValue), AccDoc);
+            ({_K, _FieldValue}, AccDoc) ->
+                AccDoc
+        end, Doc, FieldList).
 
 get_field_type(FieldName, Fields) ->
-  case [ sumo_internal:field_type(Field)
-        || Field <- Fields, sumo_internal:field_name(Field) == FieldName
-        ] of
-    [] -> undefined;
-    [FieldType | _] -> FieldType
-  end.
+    case [ sumo_internal:field_type(Field)
+          || Field <- Fields, sumo_internal:field_name(Field) == FieldName
+          ] of
+        [] -> undefined;
+        [FieldType | _] -> FieldType
+    end.
 
 denormalize_value(date, Value) ->
-  {Date, _} = iso8601:parse(Value),
-  Date;
+    {Date, _} = iso8601:parse(Value),
+    Date;
 denormalize_value(datetime, Value) ->
-  DateTime = iso8601:parse(Value),
-  DateTime;
+    DateTime = iso8601:parse(Value),
+    DateTime;
 denormalize_value(_Type, Value) ->
-  Value.
+    Value.

--- a/test/sumo_basic_SUITE.erl
+++ b/test/sumo_basic_SUITE.erl
@@ -72,9 +72,7 @@ delete(_Config) ->
   run_all_stores(fun delete_module/1).
 
 check_proper_dates(_Config) ->
-  lists:foreach(
-    fun check_proper_dates_module/1,
-    sumo_test_utils:people_with_proper_dates()).
+  run_all_stores(fun check_proper_dates_module/1).
 
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Internal functions

--- a/test/sumo_test_people_elasticsearch.erl
+++ b/test/sumo_test_people_elasticsearch.erl
@@ -31,8 +31,8 @@ sumo_schema() ->
      sumo:new_field(name,       string, [{length, 255}, not_null]),
      sumo:new_field(last_name,  string, [{length, 255}, not_null]),
      sumo:new_field(age,        integer),
-     sumo:new_field(address,    string, [{length, 255}]) %,
-     % sumo:new_field(birthdate,  date),
-     % sumo:new_field(created_at, datetime)
+     sumo:new_field(address,    string, [{length, 255}]),
+     sumo:new_field(birthdate,  date),
+     sumo:new_field(created_at, datetime)
     ],
   sumo:new_schema(?MODULE, Fields).

--- a/test/sumo_test_utils.erl
+++ b/test/sumo_test_utils.erl
@@ -9,7 +9,6 @@
   , people_with_like/0
   , people_with_numeric_sort/0
   , sleep_if_required/1
-  , people_with_proper_dates/0
   ]).
 
 -spec start_apps() -> ok.
@@ -55,7 +54,3 @@ sleep_if_required(Module) ->
     sumo_test_people_riak -> timer:sleep(5000);
     _                     -> ok
   end.
-
--spec people_with_proper_dates() -> [atom()].
-people_with_proper_dates() ->
-  all_people() -- [sumo_test_people_elasticsearch].


### PR DESCRIPTION
After #182, ES backend will no longer pass the tests. It needs some adaptations (particularly regarding schema creation, id fields and date[time]s