### PR TITLE
Fixed issue UNIQUE constraint in sumo_store_pgsql

### DIFF
--- a/src/sumo_store_pgsql.erl
+++ b/src/sumo_store_pgsql.erl
@@ -358,7 +358,7 @@ create_index(Name, id) ->
   ["PRIMARY KEY(", escape(atom_to_list(Name)), ")"];
 create_index(Name, unique) ->
   List = atom_to_list(Name),
-  ["UNIQUE KEY ", escape(List), " (", escape(List), ")"];
+  ["UNIQUE ", " (", escape(List), ")"];
 create_index(Name, index) ->
   List = atom_to_list(Name),
   ["KEY ", escape(List), " (", escape(List), ")"];


### PR DESCRIPTION
Fixed issue UNIQUE constraint in  sumo_store_pgsql

```
sumo_schema() ->
    Fields = [
              sumo:new_field(id,          integer,  [id, auto_increment]),
              sumo:new_field(key,         integer,  [not_null, unique]),
              sumo:new_field(value,       string,   [{length, 255}, not_null]),
              sumo:new_field(created_at,  datetime, [not_null])
             ],
    sumo:new_schema(?MODULE, Fields).
```

```
{error,{mytrails,{{error,error,<<"42601">>,
                         <<"syntax error at or near \"KEY\"">>,
                         [{position,<<"184">>}]},
                  {mytrails_app,start_phase,
                                [create_trail_schema,normal,[]]}}}}
```