### PR TITLE
Sumo is not filtering by datetime fields correctly

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,7 @@ CT_OPTS = -cover test/sumo.coverspec -vvv -erl_args -boot start_sasl -config ${C
 
 SHELL_OPTS = -name ${PROJECT}@`hostname` -config ${CONFIG} -boot start_sasl -s sync
 
-test-shell: build-ct-suites app
+test-shell: test-build app
 	erl  -name ${PROJECT}@`hostname` -pa ebin -pa deps/*/ebin -pa test -s lager -s sync -config ${CONFIG}
 
 erldocs:

--- a/Makefile
+++ b/Makefile
@@ -5,19 +5,21 @@ CONFIG ?= test/test.config
 DEPS = lager uuid emysql emongo tirerl epgsql worker_pool riakc iso8601
 SHELL_DEPS = sync
 
-dep_sync = git https://github.com/inaka/sync.git 0.1.3
-dep_lager = git https://github.com/basho/lager.git 2.1.1
+dep_sync = git https://github.com/rustyio/sync.git 9c78e7b
+dep_lager = git https://github.com/basho/lager.git 3.0.1
 dep_emysql = git https://github.com/inaka/Emysql.git 0.4.2
 dep_emongo = git https://github.com/inaka/emongo.git v0.2.1
 dep_tirerl = git https://github.com/inaka/tirerl 0278e0856c
 dep_epgsql = git https://github.com/epgsql/epgsql 2.0.0
-dep_worker_pool = git https://github.com/inaka/worker_pool.git 1.0.3
+dep_worker_pool = git https://github.com/inaka/worker_pool.git 1.0.4
 dep_riakc = git https://github.com/inaka/riak-erlang-client.git 2.1.1-R18
 dep_uuid = git https://github.com/okeuday/uuid.git 31f408f4ef
 dep_iso8601 = git https://github.com/zerotao/erlang_iso8601.git 0d14540
 
 TEST_DEPS = mixer
 dep_mixer = git git://github.com/inaka/mixer.git 0.1.2
+
+CT_SUITES ?= conditional_logic sumo_basic sumo_config sumo_find
 
 include erlang.mk
 

--- a/src/sumo_store_mnesia.erl
+++ b/src/sumo_store_mnesia.erl
@@ -273,10 +273,10 @@ condition_to_guard({'not', Expr}, FieldsMap) ->
 condition_to_guard({Name1, Op, Name2}, FieldsMap) when is_atom(Name2) ->
   check_operator(Op),
   %NOTE: Name2 can be a field name or a value, that's why the following happens
-  {Op, maps:get(Name1, FieldsMap), maps:get(Name2, FieldsMap, Name2)};
+  {Op, maps:get(Name1, FieldsMap), maps:get(Name2, FieldsMap, {const, Name2})};
 condition_to_guard({Name1, Op, Value}, FieldsMap) ->
   check_operator(Op),
-  {Op, maps:get(Name1, FieldsMap), Value};
+  {Op, maps:get(Name1, FieldsMap), {const, Value}};
 condition_to_guard({Name, 'null'}, FieldsMap) ->
   condition_to_guard({Name, '==', undefined}, FieldsMap);
 condition_to_guard({Name, 'not_null'}, FieldsMap) ->

--- a/test/conditional_logic_SUITE.erl
+++ b/test/conditional_logic_SUITE.erl
@@ -67,9 +67,11 @@ end_per_suite(Config) ->
 backward_compatibility(_Config) ->
   lists:foreach(
     fun do_backward_compatibility/1,
-    sumo_test_utils:people_with_conditional_logic()).
+    sumo_test_utils:people_with_conditional_logic()),
+  {comment, ""}.
 
 do_backward_compatibility(Module) ->
+  ct:comment("backward_compatibility with ~p", [Module]),
   [_, _, _, _, _] = sumo:find_all(Module),
 
   [_, _, _] = sumo:find_by(Module, [{last_name, "Doe"}]),
@@ -79,9 +81,11 @@ do_backward_compatibility(Module) ->
 or_conditional(_Config) ->
   lists:foreach(
     fun do_or_conditional/1,
-    sumo_test_utils:people_with_conditional_logic()).
+    sumo_test_utils:people_with_conditional_logic()),
+  {comment, ""}.
 
 do_or_conditional(Module) ->
+  ct:comment("or_conditional with ~p", [Module]),
   [_, _, _] = sumo:find_by(Module,
                            {'or', [{name, "John"},
                                    {name, "Joe"},
@@ -102,9 +106,11 @@ do_or_conditional(Module) ->
 and_conditional(_Config) ->
   lists:foreach(
     fun do_and_conditional/1,
-    sumo_test_utils:people_with_conditional_logic()).
+    sumo_test_utils:people_with_conditional_logic()),
+  {comment, ""}.
 
 do_and_conditional(Module) ->
+  ct:comment("and_conditional with ~p", [Module]),
   [] = sumo:find_by(Module,
                     {'and', [{name, "John"},
                              {name, "Joe"},
@@ -126,9 +132,11 @@ do_and_conditional(Module) ->
 not_null_conditional(_Config) ->
   lists:foreach(
     fun do_not_null_conditional/1,
-    sumo_test_utils:people_with_conditional_logic()).
+    sumo_test_utils:people_with_conditional_logic()),
+  {comment, ""}.
 
 do_not_null_conditional(Module) ->
+  ct:comment("not_null_conditional with ~p", [Module]),
   [_, _, _] = sumo:find_by(Module, {age, 'not_null'}),
 
   [_] = sumo:find_by(Module, {address, 'not_null'}).
@@ -137,9 +145,11 @@ do_not_null_conditional(Module) ->
 null_conditional(_Config) ->
   lists:foreach(
     fun do_null_conditional/1,
-    sumo_test_utils:people_with_conditional_logic()).
+    sumo_test_utils:people_with_conditional_logic()),
+  {comment, ""}.
 
 do_null_conditional(Module) ->
+  ct:comment("null_conditional with ~p", [Module]),
   [_, _] = sumo:find_by(Module, {age, 'null'}),
 
   [_, _, _, _] = sumo:find_by(Module, {address, 'null'}).
@@ -147,9 +157,11 @@ do_null_conditional(Module) ->
 operators(_Config) ->
   lists:foreach(
     fun do_operators/1,
-    sumo_test_utils:people_with_numeric_sort()).
+    sumo_test_utils:people_with_numeric_sort()),
+  {comment, ""}.
 
 do_operators(Module) ->
+  ct:comment("operators with ~p", [Module]),
   [_, _] = sumo:find_by(Module,
                         {'and', [{age, 'not_null'},
                                  {age, '<', 100}
@@ -215,9 +227,11 @@ do_operators(Module) ->
 deeply_nested(_Config) ->
   lists:foreach(
     fun do_deeply_nested/1,
-    sumo_test_utils:people_with_conditional_logic()).
+    sumo_test_utils:people_with_conditional_logic()),
+  {comment, ""}.
 
 do_deeply_nested(Module) ->
+  ct:comment("deeply_nested with ~p", [Module]),
   Conditions = {'or', [{'and', [{age, '>', 100},
                                 {address, '==', "something"}]},
                        {age, 'null'},

--- a/test/conditional_logic_SUITE.erl
+++ b/test/conditional_logic_SUITE.erl
@@ -13,7 +13,8 @@
          not_null_conditional/1,
          null_conditional/1,
          operators/1,
-         deeply_nested/1
+         deeply_nested/1,
+         dates/1
         ]).
 
 -define(EXCLUDED_FUNS,
@@ -63,6 +64,28 @@ end_per_suite(Config) ->
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 %%% Tests cases
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
+
+dates(_Config) ->
+  lists:foreach(
+    fun do_dates/1,
+    sumo_test_utils:people_with_conditional_logic()),
+  {comment, ""}.
+
+do_dates(Module) ->
+  ct:comment("dates with ~p", [Module]),
+  [_, _, _, _, _] = sumo:find_all(Module),
+
+  Now = {Today, _} = calendar:universal_time(),
+
+  [] = sumo:find_by(Module, [{birthdate, '>', Today}]),
+
+  [_, _, _, _, _] = sumo:find_by(Module, [{birthdate, '==', Today}]),
+
+  [_, _, _, _, _] = sumo:find_by(Module, [{birthdate, '=<', Today}]),
+
+  [] = sumo:find_by(Module, [{created_at, '>', Now}]),
+
+  [_, _, _, _, _] = sumo:find_by(Module, [{created_at, '=<', Now}]).
 
 backward_compatibility(_Config) ->
   lists:foreach(


### PR DESCRIPTION
If I use plain datetime (`{{2015, 12, 14}, {20, 50, 20}}`) for filtering I get this error:
```
12> sumo:find_by(canillita_newsitems, [{created_at, '>', {{2015, 12, 14}, {20, 50, 20}}}]).  
Mnesia(nonode@nohost): Transaction {tid,35,<0.189.0>} calling #Fun<sumo_store_mnesia.2.101953560> with [] failed: 
 {aborted,{badarg,[canillita_newsitems,
                   [{{canillita_newsitems,'$1','$2','$3','$4','$5'},
                     [{'>','$5',{{2015,12,14},{20,50,20}}}],
                     ['$_']}]]}}
** exception throw: {error,{badarg,[canillita_newsitems,
                                    [{{canillita_newsitems,'$1','$2','$3','$4','$5'},
                                      [{'>','$5',{{2015,12,14},{20,50,20}}}],
                                      ['$_']}]]}}
     in function  sumo:find_by/2 (src/sumo.erl, line 136)
```

If I use datetime like an atom (`'{{2015, 12, 14}, {20, 50, 20}}'`) it works as expected:

```
11> sumo:find_by(canillita_newsitems, [{created_at, '>', '{{2015, 12, 14}, {20, 50, 20}}'}]).
[#{body => <<"body1">>,
   created_at => {{2015,12,14},{20,51,20}},
   id => <<"1b62ce01-59a2-4e70-8388-88d264ae0f72">>,
   newspaper_name => <<"newspaper1">>,
   title => <<"title1">>}]
```