### PR TITLE
[Fix #203] Fix null values for every store

### DIFF
--- a/src/sumo_store_mnesia.erl
+++ b/src/sumo_store_mnesia.erl
@@ -360,8 +360,13 @@ wakeup(Doc) ->
 %% @private
 wakeup_fun({date, _, {Date, _} = _FieldValue}) ->
   Date;
+%% Matches `text' type fields that were saved with `undefined' value and
+%% avoids being processed by the next clause that will return it as a
+%% binary (`<<"undefined">>') instead of atom as expected.
+wakeup_fun({_, _, undefined}) ->
+  undefined;
 wakeup_fun({string, _, FieldValue}) ->
-  sumo_utils:to_list(FieldValue);
+  sumo_utils:to_bin(FieldValue);
 wakeup_fun({binary, _, FieldValue}) ->
   sumo_utils:to_bin(FieldValue);
 wakeup_fun({text, _, FieldValue}) ->

--- a/src/sumo_store_pgsql.erl
+++ b/src/sumo_store_pgsql.erl
@@ -374,7 +374,12 @@ wakeup(Doc) ->
   sumo_utils:doc_transform(fun wakeup_fun/1, Doc).
 
 %% @private
+%% Matches `text' type fields that were saved with `undefined' value and
+%% avoids being processed by the next clause that will return it as a
+%% binary (`<<"undefined">>') instead of atom as expected.
+wakeup_fun({_, _, null}) ->
+  undefined;
 wakeup_fun({string, _, FieldValue}) ->
-  sumo_utils:to_list(FieldValue);
+  sumo_utils:to_bin(FieldValue);
 wakeup_fun({_, _, FieldValue}) ->
   FieldValue.

--- a/test/conditional_logic_SUITE.erl
+++ b/test/conditional_logic_SUITE.erl
@@ -48,7 +48,10 @@ init_per_suite(Config) ->
         sumo:persist(Module, Module:new(<<"John">>, <<"Doe">>, 30)),
         sumo:persist(Module, Module:new(<<"Jane Jr.">>, <<"Doe">>, 5)),
         sumo:persist(Module, Module:new(<<"Joe">>, <<"Armstrong">>)),
-        sumo:persist(Module, Module:new(<<"Alan">>, <<"Turing">>, 102, <<"Computer St.">>)),
+        sumo:persist(Module, Module:new(<<"Alan">>,
+                                        <<"Turing">>,
+                                        102,
+                                        <<"Computer St.">>)),
 
         sumo_test_utils:sleep_if_required(Module)
     end,

--- a/test/conditional_logic_SUITE.erl
+++ b/test/conditional_logic_SUITE.erl
@@ -44,11 +44,11 @@ init_per_suite(Config) ->
         sumo:create_schema(Module),
         sumo:delete_all(Module),
 
-        sumo:persist(Module, Module:new("Jane", "Doe")),
-        sumo:persist(Module, Module:new("John", "Doe", 30)),
-        sumo:persist(Module, Module:new("Jane Jr.", "Doe", 5)),
-        sumo:persist(Module, Module:new("Joe", "Armstrong")),
-        sumo:persist(Module, Module:new("Alan", "Turing", 102, "Computer St.")),
+        sumo:persist(Module, Module:new(<<"Jane">>, <<"Doe">>)),
+        sumo:persist(Module, Module:new(<<"John">>, <<"Doe">>, 30)),
+        sumo:persist(Module, Module:new(<<"Jane Jr.">>, <<"Doe">>, 5)),
+        sumo:persist(Module, Module:new(<<"Joe">>, <<"Armstrong">>)),
+        sumo:persist(Module, Module:new(<<"Alan">>, <<"Turing">>, 102, <<"Computer St.">>)),
 
         sumo_test_utils:sleep_if_required(Module)
     end,
@@ -73,15 +73,15 @@ dates(_Config) ->
 
 do_dates(Module) ->
   ct:comment("dates with ~p", [Module]),
-  5 = length(sumo:find_all(Module)),
+  [_, _, _, _, _] = sumo:find_all(Module),
 
   Now = {Today, _} = calendar:universal_time(),
 
-  0 = length(sumo:find_by(Module, [{birthdate, '>', Today}])),
-  5 = length(sumo:find_by(Module, [{birthdate, '==', Today}])),
-  5 = length(sumo:find_by(Module, [{birthdate, '=<', Today}])),
-  0 = length(sumo:find_by(Module, [{created_at, '>', Now}])),
-  5 = length(sumo:find_by(Module, [{created_at, '=<', Now}])).
+  [] = sumo:find_by(Module, [{birthdate, '>', Today}]),
+  [_, _, _, _, _] = sumo:find_by(Module, [{birthdate, '==', Today}]),
+  [_, _, _, _, _] = sumo:find_by(Module, [{birthdate, '=<', Today}]),
+  [] = sumo:find_by(Module, [{created_at, '>', Now}]),
+  [_, _, _, _, _] = sumo:find_by(Module, [{created_at, '=<', Now}]).
 
 backward_compatibility(_Config) ->
   lists:foreach(
@@ -91,9 +91,9 @@ backward_compatibility(_Config) ->
 
 do_backward_compatibility(Module) ->
   ct:comment("backward_compatibility with ~p", [Module]),
-  5 = length(sumo:find_all(Module)),
-  3 = length(sumo:find_by(Module, [{last_name, "Doe"}])),
-  1 = length(sumo:find_by(Module, [{name, "Jane"}, {last_name, "Doe"}])).
+  [_, _, _, _, _] = sumo:find_all(Module),
+  [_, _, _] = sumo:find_by(Module, [{last_name, <<"Doe">>}]),
+  [_] = sumo:find_by(Module, [{name, <<"Jane">>}, {last_name, <<"Doe">>}]).
 
 or_conditional(_Config) ->
   lists:foreach(
@@ -103,19 +103,19 @@ or_conditional(_Config) ->
 
 do_or_conditional(Module) ->
   ct:comment("or_conditional with ~p", [Module]),
-  3 = length(sumo:find_by(Module,
-                          {'or', [{name, "John"},
-                                  {name, "Joe"},
-                                  {name, "Alan"}
-                                 ]
-                          })),
-
-  2 = length(sumo:find_by(Module,
-                          [{last_name, "Doe"},
-                           {'or', [{name, "Jane"},
-                                   {name, "Jane Jr."}
+  [_, _, _] = sumo:find_by(Module,
+                           {'or', [{name, <<"John">>},
+                                   {name, <<"Joe">>},
+                                   {name, <<"Alan">>}
                                   ]
-                           }])).
+                           }),
+
+  [_, _] = sumo:find_by(Module,
+                   [{last_name, <<"Doe">>},
+                    {'or', [{name, <<"Jane">>},
+                            {name, <<"Jane Jr.">>}
+                           ]
+                    }]).
 
 and_conditional(_Config) ->
   lists:foreach(
@@ -125,21 +125,21 @@ and_conditional(_Config) ->
 
 do_and_conditional(Module) ->
   ct:comment("and_conditional with ~p", [Module]),
-  0 = length(sumo:find_by(Module,
-                          {'and', [{name, "John"},
-                                   {name, "Joe"},
-                                   {name, "Alan"}
-                                  ]
-                          })),
+  [] = sumo:find_by(Module,
+                    {'and', [{name, <<"John">>},
+                             {name, <<"Joe">>},
+                             {name, <<"Alan">>}
+                            ]
+                    }),
 
-  2 = length(sumo:find_by(Module,
-                          {'and', [{last_name, "Doe"},
-                                   {'or', [{name, "Jane"},
-                                           {name, "Jane Jr."}
-                                          ]
-                                   }
-                                  ]
-                          })).
+  [_, _] = sumo:find_by(Module,
+                        {'and', [{last_name, <<"Doe">>},
+                                 {'or', [{name, <<"Jane">>},
+                                         {name, <<"Jane Jr.">>}
+                                        ]
+                                 }
+                                ]
+                        }).
 
 not_null_conditional(_Config) ->
   lists:foreach(
@@ -149,8 +149,8 @@ not_null_conditional(_Config) ->
 
 do_not_null_conditional(Module) ->
   ct:comment("not_null_conditional with ~p", [Module]),
-  5 = length(sumo:find_by(Module, {age, 'not_null'})),
-  5 = length(sumo:find_by(Module, {address, 'not_null'})).
+  [_, _, _] = sumo:find_by(Module, {age, 'not_null'}),
+  [_] = sumo:find_by(Module, {address, 'not_null'}).
 
 null_conditional(_Config) ->
   lists:foreach(
@@ -160,8 +160,8 @@ null_conditional(_Config) ->
 
 do_null_conditional(Module) ->
   ct:comment("null_conditional with ~p", [Module]),
-  0 = length(sumo:find_by(Module, {age, 'null'})),
-  0 = length(sumo:find_by(Module, {address, 'null'})).
+  [_, _] = sumo:find_by(Module, {age, 'null'}),
+  [_, _, _, _] = sumo:find_by(Module, {address, 'null'}).
 
 operators(_Config) ->
   lists:foreach(
@@ -171,61 +171,61 @@ operators(_Config) ->
 
 do_operators(Module) ->
   ct:comment("operators with ~p", [Module]),
-  4 = length(sumo:find_by(Module,
-                          {'and', [{age, 'not_null'},
-                                   {age, '<', 100}
+  [_, _] = sumo:find_by(Module,
+                        {'and', [{age, 'not_null'},
+                                 {age, '<', 100}
+                                ]
+                        }),
+
+  [_] = sumo:find_by(Module,
+                     {'and', [{age, 'not_null'},
+                              {age, '>', 100}
+                             ]
+                     }),
+
+  [] = sumo:find_by(Module,
+                    {'and', [{age, 'not_null'},
+                             {age, '>', 102}
+                            ]
+                    }),
+
+  [_] = sumo:find_by(Module,
+                     {'and', [{age, 'not_null'},
+                              {age, '>=', 102}
+                             ]
+                     }),
+
+
+  [_] = sumo:find_by(Module,
+                     {'and', [{age, 'not_null'},
+                              {age, '<', 30}
+                             ]
+                     }),
+
+  [_, _] = sumo:find_by(Module,
+                        {'and', [{age, 'not_null'},
+                                 {age, '=<', 30}
+                                ]
+                        }),
+
+  [_, _, _] = sumo:find_by(Module,
+                           {'or', [{age, 'null'},
+                                   {age, '==', 30}
                                   ]
-                          })),
+                           }),
 
-  1 = length(sumo:find_by(Module,
-                          {'and', [{age, 'not_null'},
-                                   {age, '>', 100}
-                                  ]
-                          })),
-
-  0 = length(sumo:find_by(Module,
-                          {'and', [{age, 'not_null'},
-                                   {age, '>', 102}
-                                  ]
-                          })),
-
-  1 = length(sumo:find_by(Module,
-                          {'and', [{age, 'not_null'},
-                                   {age, '>=', 102}
-                                  ]
-                          })),
-
-
-  3 = length(sumo:find_by(Module,
-                          {'and', [{age, 'not_null'},
-                                   {age, '<', 30}
-                                  ]
-                          })),
-
-  4 = length(sumo:find_by(Module,
-                          {'and', [{age, 'not_null'},
-                                   {age, '=<', 30}
-                                  ]
-                          })),
-
-  1 = length(sumo:find_by(Module,
-                          {'or', [{age, 'null'},
-                                  {age, '==', 30}
-                                 ]
-                          })),
-
-  4 = length(sumo:find_by(Module,
-                          {'and', [{age, 'not_null'},
-                                   {age, '/=', 30}
-                                  ]
-                          })),
+  [_, _] = sumo:find_by(Module,
+                        {'and', [{age, 'not_null'},
+                                 {age, '/=', 30}
+                                ]
+                        }),
 
   case lists:member(Module, sumo_test_utils:people_with_like()) of
     true ->
-      4 = length(sumo:find_by(Module, {name, 'like', "J%"})),
-      2 = length(sumo:find_by(Module, {'and', [{name, 'like', "Ja%"}]})),
-      1 = length(sumo:find_by(Module, {name, 'like', "A%"})),
-      2 = length(sumo:find_by(Module, {name, 'like', "%n"}));
+      [_, _, _, _] = sumo:find_by(Module, {name, 'like', <<"J%">>}),
+      [_, _] = sumo:find_by(Module, {'and', [{name, 'like', <<"Ja%">>}]}),
+      [_] = sumo:find_by(Module, {name, 'like', <<"A%">>}),
+      [_, _] = sumo:find_by(Module, {name, 'like', <<"%n">>});
     false ->
       ok
   end.
@@ -239,9 +239,9 @@ deeply_nested(_Config) ->
 do_deeply_nested(Module) ->
   ct:comment("deeply_nested with ~p", [Module]),
   Conditions = {'or', [{'and', [{age, '>', 100},
-                                {address, '==', "something"}]},
+                                {address, '==', <<"something">>}]},
                        {age, 'null'},
-                       {last_name, "Turing"}
+                       {last_name, <<"Turing">>}
                       ]
                },
-  1 = length(sumo:find_by(Module, Conditions)).
+  [_, _, _] = sumo:find_by(Module, Conditions).

--- a/test/sumo_basic_SUITE.erl
+++ b/test/sumo_basic_SUITE.erl
@@ -133,7 +133,8 @@ find_by_module(Module) ->
   undefined = Module:description(First),
   {Today, _} = Module:created_at(First),
   % Check that it returns what we have inserted
-  [LastPerson | _NothingElse] = sumo:find_by(Module, [{last_name, <<"LastName">>}]),
+  [LastPerson | _NothingElse] = sumo:find_by(Module,
+                                             [{last_name, <<"LastName">>}]),
   <<"Name">> = Module:name(LastPerson),
   <<"LastName">> = Module:last_name(LastPerson),
   3 = Module:age(LastPerson),

--- a/test/sumo_basic_SUITE.erl
+++ b/test/sumo_basic_SUITE.erl
@@ -92,10 +92,10 @@ init_store(Module) ->
   sumo:persist(
     Module,
     Module:new(
-     "Name",
-     "LastName",
+     <<"Name">>,
+     <<"LastName">>,
      3,
-     "",
+     undefined,
      {2016, 2, 05},
      1.75,
      <<"My description text">>
@@ -112,32 +112,32 @@ find_module(Module) ->
   notfound = sumo:find(Module, 0).
 
 find_all_module(Module) ->
-  8 = length(sumo:find_all(Module)).
+  [_, _, _, _, _, _, _, _] = sumo:find_all(Module).
 
 find_by_module(Module) ->
   Results = sumo:find_by(Module, [{last_name, <<"D">>}]),
-  2 = length(Results),
+  [_, _] = Results,
   SortFun = fun(A, B) -> Module:name(A) < Module:name(B) end,
   [First, Second | _] = lists:sort(SortFun, Results),
 
   {Today, _} = calendar:universal_time(),
 
-  "B" = to_str(Module:name(First)),
-  "D" = to_str(Module:name(Second)),
+  <<"B">> = Module:name(First),
+  <<"D">> = Module:name(Second),
   3 = Module:age(First),
   4 = Module:age(Second),
-  "D" = Module:last_name(First),
-  "" = Module:address(First),
+  <<"D">> = Module:last_name(First),
+  undefined = Module:address(First),
   Today = Module:birthdate(First),
-  0.0 = Module:height(First),
-  <<>> = Module:description(First),
+  undefined = Module:height(First),
+  undefined = Module:description(First),
   {Today, _} = Module:created_at(First),
   % Check that it returns what we have inserted
-  [LastPerson | _NothingElse] = sumo:find_by(Module, [{last_name, "LastName"}]),
-  "Name" = Module:name(LastPerson),
-  "LastName" = Module:last_name(LastPerson),
+  [LastPerson | _NothingElse] = sumo:find_by(Module, [{last_name, <<"LastName">>}]),
+  <<"Name">> = Module:name(LastPerson),
+  <<"LastName">> = Module:last_name(LastPerson),
   3 = Module:age(LastPerson),
-  "" = Module:address(LastPerson),
+  undefined = Module:address(LastPerson),
   {2016, 2, 05} = Module:birthdate(LastPerson),
   1.75 = Module:height(LastPerson),
   <<"My description text">> = Module:description(LastPerson),
@@ -148,12 +148,12 @@ find_by_module(Module) ->
   First1 = First,
   %% Check pagination
   Results1 = sumo:find_by(Module, [], 3, 1),
-  3 = length(Results1),
+  [_, _, _] = Results1,
 
   %% This test is #177 github issue related
-  8 = length(sumo:find_by(Module, [])),
+  [_, _, _, _, _, _, _, _] = sumo:find_by(Module, []),
   Robot = sumo:find_by(Module, [{name, <<"Model T-2000">>}]),
-  1 = length(Robot).
+  [_] = Robot.
 
 delete_all_module(Module) ->
   sumo:delete_all(Module),
@@ -165,7 +165,7 @@ delete_module(Module) ->
   sync_timeout(Module),
   Results = sumo:find_by(Module, [{last_name, <<"D">>}]),
 
-  0 = length(Results),
+  [] = Results,
 
   %% delete
   [First | _ ] = All = sumo:find_all(Module),
@@ -173,7 +173,7 @@ delete_module(Module) ->
   sumo:delete(Module, Id),
   NewAll = sumo:find_all(Module),
 
-  1 = length(All) - length(NewAll).
+  [_] = All -- NewAll.
 
 check_proper_dates_module(Module) ->
   [P0] = sumo:find_by(Module, [{name, <<"A">>}]),
@@ -197,12 +197,6 @@ check_proper_dates_module(Module) ->
 -spec run_all_stores(fun()) -> ok.
 run_all_stores(Fun) ->
   lists:foreach(Fun, sumo_test_utils:all_people()).
-
--spec to_str(any()) -> string().
-to_str(X) when is_list(X) ->
-  X;
-to_str(X) when is_binary(X) ->
-  binary_to_list(X).
 
 -spec sync_timeout(module()) -> ok.
 sync_timeout(Module) ->

--- a/test/sumo_test_people.erl
+++ b/test/sumo_test_people.erl
@@ -26,11 +26,11 @@
          description/1,
          profile_image/1]).
 
--record(person, {id :: integer(),
-                 name :: string(),
-                 last_name :: string(),
+-record(person, {id :: integer() | binary(),
+                 name :: binary(),
+                 last_name :: binary(),
                  age :: integer(),
-                 address :: string(),
+                 address :: binary(),
                  birthdate  :: calendar:date(),
                  created_at :: calendar:datetime(),
                  height :: float(),
@@ -75,21 +75,21 @@ sumo_wakeup(Person) ->
 %%% Exported
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 
-new(Name, LastName) -> new(Name, LastName, 0).
+new(Name, LastName) -> new(Name, LastName, undefined).
 
-new(Name, LastName, Age) -> new(Name, LastName, Age, "").
+new(Name, LastName, Age) -> new(Name, LastName, Age, undefined).
 
 new(Name, LastName, Age, Address) ->
   {BirthDate, _} = calendar:universal_time(),
   new(Name, LastName, Age, Address, BirthDate).
 
 new(Name, LastName, Age, Address, BirthDate) ->
-  new(Name, LastName, Age, Address, BirthDate, 0.0).
+  new(Name, LastName, Age, Address, BirthDate, undefined).
 new(Name, LastName, Age, Address, BirthDate, Height) ->
-  new(Name, LastName, Age, Address, BirthDate, Height, "").
+  new(Name, LastName, Age, Address, BirthDate, Height, undefined).
 
 new(Name, LastName, Age, Address, BirthDate, Height, Description) ->
-  new(Name, LastName, Age, Address, BirthDate, Height, Description, <<>>).
+  new(Name, LastName, Age, Address, BirthDate, Height, Description, undefined).
 
 new(Name,
     LastName,


### PR DESCRIPTION
- Set SumoDB to treat string and text type fields as binary
- Switch to pattern matching instead of list length in tests

Note: after talking with @cabol  and since `Riak` doesn't have the concept of `null`, we have chosen to use `$nil` as a reserved word within `SumoDB` for `Riak` **null** values.