### PR TITLE
Enforce that schema has at least a field with at least `id` attribute

### DIFF
--- a/src/sumo_internal.erl
+++ b/src/sumo_internal.erl
@@ -85,7 +85,9 @@
 %% @doc Returns a new schema.
 -spec new_schema(sumo:schema_name(), [field()]) -> schema().
 new_schema(Name, Fields) ->
-  #{name => Name, fields => Fields}.
+  S = #{name => Name, fields => Fields},
+  _ = get_id_field(S),
+  S.
 
 %% @doc Returns a new field of the given type and attributes.
 -spec new_field(


### PR DESCRIPTION
This change is in the context of highlighting in sumo_rest the role of
the `:id` binding in the cowboy route.

See also https://github.com/inaka/sumo_db/pull/293#issuecomment-284895140