### PR TITLE
sumo:fetch/2 replaced sumo:find/2 in /examples/blog/src/blog.erl

### DIFF
--- a/examples/blog/src/blog.erl
+++ b/examples/blog/src/blog.erl
@@ -57,17 +57,17 @@ find_authors_by_name(Name, Limit, Offset) ->
 %% @doc Finds a post given the id.
 -spec find_post(blog_post:id()) -> blog_post:post()|notfound.
 find_post(Id) ->
-  sumo:fetch(post, Id).
+  sumo:find(post, Id).
 
 %% @doc Finds an author, given the id.
 -spec find_author(blog_author:id()) -> blog_author:author()|notfound.
 find_author(Id) ->
-  sumo:fetch(author, Id).
+  sumo:find(author, Id).
 
 %% @doc Find a reader, given the id.
 -spec find_reader(blog_reader:id()) -> blog_reader:reader()|notfound.
 find_reader(Id) ->
-  sumo:fetch(reader, Id).
+  sumo:find(reader, Id).
 
 %% @doc Returns all available posts.
 -spec total_posts() -> non_neg_integer().


### PR DESCRIPTION
escript file  /examples/blog/run was generating error
**escript: exception error: undefined function sumo:fetch/2**
which was caused by deprecated sumo:fetch/2 function being used .
function was replaced with sumo:find/2 which caused the escript to run without errors
