### PR TITLE
fix for events env variable  ommitted 0.6.1

### DIFF
--- a/src/sumo_event.erl
+++ b/src/sumo_event.erl
@@ -51,7 +51,7 @@ dispatch(DocName, Event, Args) ->
   DocName :: sumo:schema_name(),
   Res     :: undefined | atom()| {atom(), term()}.
 get_event_manager(DocName) ->
-  {ok, Docs} = application:get_env(sumo_db, events),
+  Docs = application:get_env(sumo_db, events, []),
   case Docs of
     undefined ->
       undefined;


### PR DESCRIPTION
	fix for when events env variable is omitted
	in config file which causes code to crash