### PR TITLE
Fix find_by when offset is greater than available objects

### DIFF
--- a/src/adapter_test_helpers/sumo_basic_test_helper.erl
+++ b/src/adapter_test_helpers/sumo_basic_test_helper.erl
@@ -108,6 +108,8 @@ find_by(Config) ->
   %% Check pagination
   Results1 = sumo:find_by(Name, [], 3, 1),
   [_, _, _] = Results1,
+  [_, _, _, _, _, _, _] = sumo:find_by(Name, [], 1000, 1),
+  [] = sumo:find_by(Name, [], 1, 1000),
 
   %% This test is #177 github issue related
   [_, _, _, _, _, _, _, _] = sumo:find_by(Name, []),

--- a/src/adapters/sumo_store_mnesia.erl
+++ b/src/adapters/sumo_store_mnesia.erl
@@ -188,8 +188,10 @@ find_by(DocName, Conditions, [], Limit, Offset, State) ->
   end,
   TransactionL = fun() ->
     case mnesia:select(DocName, MatchSpec, Offset + Limit, read) of
-      {ManyItems, _Cont} ->
+      {ManyItems, _Cont} when length(ManyItems) >= Offset ->
         lists:sublist(ManyItems, Offset + 1, Limit);
+      {_ManyItems, _Cont} ->
+        [];
       '$end_of_table' ->
         []
     end


### PR DESCRIPTION
If for example I want to get the page 2 from a lists of resources and there is only one page of them, the page should be empty. This is not the case with sumo:find_by, since when the offset is too high it raises an exception inside lists:sublist. I added a guard to protect against this.
When the offset is greater than the number of results, it simply returns the empty list.