### PR TITLE
Upgrade worker_pool to remove the (already deprecated) gen_fsm warning(s)

### DIFF
--- a/rebar.config
+++ b/rebar.config
@@ -24,7 +24,7 @@
 %% == Dependencies ==
 
 {deps, [
-  {worker_pool, "2.3.0"},
+  {worker_pool, {git, "https://github.com/inaka/worker_pool.git", {tag, "3.1.0"}}},
   {uuid, "1.5.2-rc1", {pkg, uuid_erl}},
   {iso8601, "1.2.3"}
 ]}.
@@ -36,7 +36,7 @@
     {deps, [
       {katana_test, {git, "https://github.com/inaka/katana-test.git", {ref, "b26165d"}}},
       {mixer, "0.1.5", {pkg, inaka_mixer}},
-      {fancyflow, {git, "https://github.com/ferd/fancyflow", {ref, "81cf9df"}}}
+      {fancyflow, {git, "https://github.com/ferd/fancyflow.git", {ref, "81cf9df"}}}
     ]}
   ]},
   {shell, [


### PR DESCRIPTION
This should do it! I ran the Dialyzer:

```bash
[gorre@uplink sumo_db]$ rebar3 dialyzer
...
===> Resolving files...
===> Checking 166 files in "./sumo_db_20.3.6_plt"...
===> Copying "./sumo_db_20.3.6_plt" to "/home/gorre/Workshop/Development/erlang/sumo_db/_build/default/sumo_db_20.3.6_plt"...
===> Checking 166 files in "/home/gorre/Workshop/Development/erlang/sumo_db/_build/default/sumo_db_20.3.6_plt"...
===> Adding 10 files to "/home/gorre/Workshop/Development/erlang/sumo_db/_build/default/sumo_db_20.3.6_plt"...
===> Doing success typing analysis...
===> Resolving files...
===> Analyzing 24 files with "/home/gorre/Workshop/Development/erlang/sumo_db/_build/default/sumo_db_20.3.6_plt"...
```

...the EUnit and Common-Test suites:

```bash
[gorre@uplink sumo_db]$ rebar3 do eunit, ct
...
===> Performing EUnit tests...

Finished in 0.213 seconds
0 tests
===> Verifying dependencies...
===> Compiling sumo_db
===> Running Common Test suites...
%%% sumo_basic_SUITE ==> create_schema: OK
%%% sumo_basic_SUITE ==> find: OK
%%% sumo_basic_SUITE ==> find_all: OK
%%% sumo_basic_SUITE ==> find_by: OK
%%% sumo_basic_SUITE ==> delete_all: OK
%%% sumo_basic_SUITE ==> delete: OK
...
%%% sumo_type_SUITE ==> t_cast_date: OK
%%% sumo_type_SUITE ==> t_cast_datetime: OK
%%% sumo_type_SUITE ==> t_cast_binary: OK
%%% sumo_type_SUITE ==> t_cast_custom: OK
All 48 tests passed.
```